### PR TITLE
Update LDAP auth

### DIFF
--- a/cmdbuild/opt/cmdbuild/setupauth.sh
+++ b/cmdbuild/opt/cmdbuild/setupauth.sh
@@ -37,6 +37,8 @@ then
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.basedn "$AUTH_LDAP_BASEDN"
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.bind.attribute $AUTH_LDAP_BIND_ATTRIBUTE
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.filter $AUTH_LDAP_SEARCH_FILTER
+  $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.enable true
+
 
 #  cat  >>$CONFCMDBUILD/auth.conf <<-EOF
 #

--- a/cmdbuild/opt/cmdbuild/setupauth.sh
+++ b/cmdbuild/opt/cmdbuild/setupauth.sh
@@ -34,7 +34,7 @@ then
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.server.address $AUTH_LDAP_SERVER_ADDRESS
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.server.port $AUTH_LDAP_SERVER_PORT
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.use.tls $AUTH_LDAP_USE_SSL
-  $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.basedn $AUTH_LDAP_BASEDN
+  $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.basedn "$AUTH_LDAP_BASEDN"
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.bind.attribute $AUTH_LDAP_BIND_ATTRIBUTE
   $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.filter $AUTH_LDAP_SEARCH_FILTER
 
@@ -58,7 +58,7 @@ then
 #     echo "ldap.search.auth.method=none" >>$CONFCMDBUILD/auth.conf
    else 
      $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.auth.method $AUTH_LDAP_SEARCH_AUTH_METHOD
-     $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.auth.principal $AUTH_LDAP_SEARCH_AUTH_PRINCIPAL
+     $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.auth.principal "$AUTH_LDAP_SEARCH_AUTH_PRINCIPAL"
      $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh restws setconfig org.cmdbuild.auth.ldap.search.auth.password $AUTH_LDAP_SEARCH_AUTH_PASSWORD
 #     echo "ldap.search.auth.method=simple" >>$CONFCMDBUILD/auth.conf
 #     cat  >>$CONFCMDBUILD/auth.conf <<-EOF2


### PR DESCRIPTION
The existing setupauth.sh had 2 major problems. 
If the AUTH_LDAP_BASEDN or AUTH_LDAP_SEARCH_AUTH_PRINCIPAL did contain a whitespace (e.g. with Azure AD DS Service), the configuration did fail due to missing quotes.
The LDAP auth needs to be explicitly enabled in newer cmdbuild releases. Therefore, the required command was added in the LDAP block.